### PR TITLE
Avoid broadcasting over a `Q` matrix

### DIFF
--- a/src/RandomQuantum.jl
+++ b/src/RandomQuantum.jl
@@ -130,10 +130,10 @@ end
 
 function rand(dist::ClosedHaarEnsemble)
     X = rand(GinibreEnsemble(dist.dim))
-    Q,_ = qr(X)
+    Q = qr(X).Q * I # yields dense square matrix
     d = diag(Q)
-    d = d ./ abs.(d)
-    Q = Q ./ d
+    d ./= abs.(d)
+    Q ./= d
     return Q
 end
 

--- a/src/RandomQuantum.jl
+++ b/src/RandomQuantum.jl
@@ -130,7 +130,7 @@ end
 
 function rand(dist::ClosedHaarEnsemble)
     X = rand(GinibreEnsemble(dist.dim))
-    Q = qr(X).Q * I # yields dense square matrix
+    Q = qr(X).Q * eye(dist.dim) # yields dense square matrix
     d = diag(Q)
     d ./= abs.(d)
     Q ./= d


### PR DESCRIPTION
This came up in a nanosoldier run related to https://github.com/JuliaLang/julia/pull/46196. Broadcasting over a `Q` matrix is superslow because it falls back to elementwise `getindex`. My proposal computes the full (square) matrix representation, and subsequently overwrites temporary storage. Especially for large `X`, this should speed up the function quite significantly.